### PR TITLE
adds a TypeScript Rug command handler to a Rug project

### DIFF
--- a/.atomist.yml
+++ b/.atomist.yml
@@ -16,3 +16,21 @@ generator:
     - "description": "bamboo grows fast, so will this elm toolbox!   ... hopefully ..."
     - "version": "0.1.0"
 
+---
+kind: "operation"
+client: "com.atomist:rug"
+version: "1.0.0-20170602144934"
+editor:
+  name: "AddTypeScriptCommandHandler"
+  group: "atomist"
+  artifact: "rug-rugs"
+  version: "0.30.1"
+  origin:
+    repo: "https://github.com/atomist/rug-rugs.git"
+    branch: "4babf5df7ea909f42b0390b5c38fb8d3632b810d"
+    sha: "4babf5d"
+  parameters:
+    - "handlerName": "OpenPullRequest"
+    - "description": "create a branch and open a pull request for it"
+    - "intent": "create pr"
+

--- a/.atomist/handlers/command/OpenPullRequest.ts
+++ b/.atomist/handlers/command/OpenPullRequest.ts
@@ -1,0 +1,30 @@
+import { CommandHandler, Intent, Parameter, Tags } from "@atomist/rug/operations/Decorators";
+import { CommandPlan, HandleCommand, HandlerContext, ResponseMessage } from "@atomist/rug/operations/Handlers";
+import { Pattern } from "@atomist/rug/operations/RugOperation";
+
+/**
+ * A create a branch and open a pull request for it.
+ */
+@CommandHandler("OpenPullRequest", "create a branch and open a pull request for it")
+@Tags("documentation")
+@Intent("create pr")
+export class OpenPullRequest implements HandleCommand {
+
+    @Parameter({
+        displayName: "Some Input",
+        description: "example of how to specify a parameter using decorators",
+        pattern: Pattern.any,
+        validInput: "a description of the valid input",
+        minLength: 1,
+        maxLength: 100,
+        required: false,
+    })
+    public inputParameter: string = "default value";
+
+    public handle(context: HandlerContext): CommandPlan {
+        const message = new ResponseMessage(`Successfully ran OpenPullRequest: ${this.inputParameter}`);
+        return CommandPlan.ofMessage(message);
+    }
+}
+
+export const openPullRequest = new OpenPullRequest();

--- a/.atomist/tests/handlers/command/OpenPullRequestSteps.ts
+++ b/.atomist/tests/handlers/command/OpenPullRequestSteps.ts
@@ -1,0 +1,17 @@
+import { ResponseMessage } from "@atomist/rug/operations/Handlers";
+import {
+    CommandHandlerScenarioWorld, Given, Then, When,
+} from "@atomist/rug/test/handler/Core";
+
+Given("nothing", (f) => { return; });
+
+When("the OpenPullRequest is invoked", (w: CommandHandlerScenarioWorld) => {
+    const handler = w.commandHandler("OpenPullRequest");
+    w.invokeHandler(handler, {});
+});
+
+Then("you get the right response", (w: CommandHandlerScenarioWorld) => {
+    const expected = "Successfully ran OpenPullRequest: default value";
+    const message = (w.plan().messages[0] as ResponseMessage).body;
+    return message === expected;
+});

--- a/.atomist/tests/handlers/command/OpenPullRequestTest.feature
+++ b/.atomist/tests/handlers/command/OpenPullRequestTest.feature
@@ -1,0 +1,10 @@
+Feature: OpenPullRequest handlers responds to commands
+  This is the sample Gherkin feature file for the BDD tests of
+  the sample TypeScript command handler used by AddOpenPullRequest.
+  Feel free to modify and extend to suit the needs of your handler.
+
+
+  Scenario: Executing a sample command handler
+    Given nothing
+    When the OpenPullRequest is invoked
+    Then you get the right response


### PR DESCRIPTION
Created by Atomist Editor `AddTypeScriptCommandHandler`
```
---
kind: "operation"
client: "com.atomist:rug"
version: "1.0.0-20170602144934"
editor:
  name: "AddTypeScriptCommandHandler"
  group: "atomist"
  artifact: "rug-rugs"
  version: "0.30.1"
  origin:
    repo: "https://github.com/atomist/rug-rugs.git"
    branch: "4babf5df7ea909f42b0390b5c38fb8d3632b810d"
    sha: "4babf5d"
  parameters:
    - "handlerName": "OpenPullRequest"
    - "description": "create a branch and open a pull request for it"
    - "intent": "create pr"

```