### PR TITLE
adds a TypeScript Rug command handler to a Rug project

### DIFF
--- a/.atomist.yml
+++ b/.atomist.yml
@@ -34,3 +34,21 @@ editor:
     - "description": "create a branch and open a pull request for it"
     - "intent": "create pr"
 
+---
+kind: "operation"
+client: "com.atomist:rug"
+version: "1.0.0-20170602144934"
+editor:
+  name: "AddTypeScriptCommandHandler"
+  group: "atomist"
+  artifact: "rug-rugs"
+  version: "0.30.1"
+  origin:
+    repo: "https://github.com/atomist/rug-rugs.git"
+    branch: "4babf5df7ea909f42b0390b5c38fb8d3632b810d"
+    sha: "4babf5d"
+  parameters:
+    - "handlerName": "ListGithubBranches"
+    - "description": "return a list of existing branches of your repo"
+    - "intent": "list branches"
+

--- a/.atomist/handlers/command/ListGithubBranches.ts
+++ b/.atomist/handlers/command/ListGithubBranches.ts
@@ -1,0 +1,30 @@
+import { CommandHandler, Intent, Parameter, Tags } from "@atomist/rug/operations/Decorators";
+import { CommandPlan, HandleCommand, HandlerContext, ResponseMessage } from "@atomist/rug/operations/Handlers";
+import { Pattern } from "@atomist/rug/operations/RugOperation";
+
+/**
+ * A return a list of existing branches of your repo.
+ */
+@CommandHandler("ListGithubBranches", "return a list of existing branches of your repo")
+@Tags("documentation")
+@Intent("list branches")
+export class ListGithubBranches implements HandleCommand {
+
+    @Parameter({
+        displayName: "Some Input",
+        description: "example of how to specify a parameter using decorators",
+        pattern: Pattern.any,
+        validInput: "a description of the valid input",
+        minLength: 1,
+        maxLength: 100,
+        required: false,
+    })
+    public inputParameter: string = "default value";
+
+    public handle(context: HandlerContext): CommandPlan {
+        const message = new ResponseMessage(`Successfully ran ListGithubBranches: ${this.inputParameter}`);
+        return CommandPlan.ofMessage(message);
+    }
+}
+
+export const listGithubBranches = new ListGithubBranches();

--- a/.atomist/tests/handlers/command/ListGithubBranchesSteps.ts
+++ b/.atomist/tests/handlers/command/ListGithubBranchesSteps.ts
@@ -1,0 +1,17 @@
+import { ResponseMessage } from "@atomist/rug/operations/Handlers";
+import {
+    CommandHandlerScenarioWorld, Given, Then, When,
+} from "@atomist/rug/test/handler/Core";
+
+Given("nothing", (f) => { return; });
+
+When("the ListGithubBranches is invoked", (w: CommandHandlerScenarioWorld) => {
+    const handler = w.commandHandler("ListGithubBranches");
+    w.invokeHandler(handler, {});
+});
+
+Then("you get the right response", (w: CommandHandlerScenarioWorld) => {
+    const expected = "Successfully ran ListGithubBranches: default value";
+    const message = (w.plan().messages[0] as ResponseMessage).body;
+    return message === expected;
+});

--- a/.atomist/tests/handlers/command/ListGithubBranchesTest.feature
+++ b/.atomist/tests/handlers/command/ListGithubBranchesTest.feature
@@ -1,0 +1,10 @@
+Feature: ListGithubBranches handlers responds to commands
+  This is the sample Gherkin feature file for the BDD tests of
+  the sample TypeScript command handler used by AddListGithubBranches.
+  Feel free to modify and extend to suit the needs of your handler.
+
+
+  Scenario: Executing a sample command handler
+    Given nothing
+    When the ListGithubBranches is invoked
+    Then you get the right response


### PR DESCRIPTION
Created by Atomist Editor `AddTypeScriptCommandHandler`
```
---
kind: "operation"
client: "com.atomist:rug"
version: "1.0.0-20170602144934"
editor:
  name: "AddTypeScriptCommandHandler"
  group: "atomist"
  artifact: "rug-rugs"
  version: "0.30.1"
  origin:
    repo: "https://github.com/atomist/rug-rugs.git"
    branch: "4babf5df7ea909f42b0390b5c38fb8d3632b810d"
    sha: "4babf5d"
  parameters:
    - "handlerName": "ListGithubBranches"
    - "description": "return a list of existing branches of your repo"
    - "intent": "list branches"

```